### PR TITLE
Added an entry point to directly call the server

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -1,5 +1,6 @@
 import re
 from socket import AF_INET, SOCK_DGRAM, socket
+import sys
 import threading
 import time
 import types
@@ -153,9 +154,8 @@ class ServerDaemon(Daemon):
         server.serve(options.name, options.port, options.graphite_host,
                      options.graphite_port)
 
-
-if __name__ == '__main__':
-    import sys
+def statsd_server_command():
+    "Entry point for command line usage"
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('-d', '--debug', dest='debug', action='store_true', help='debug mode', default=False)
@@ -179,3 +179,8 @@ if __name__ == '__main__':
         daemon.stop()
     else:
         daemon.run(options)
+    return 0
+    
+
+if __name__ == '__main__':
+    sys.exit(statsd_server_command())

--- a/setup.py
+++ b/setup.py
@@ -18,4 +18,8 @@ setup(
     classifiers=[
         "License :: OSI Approved :: BSD License",
     ],
+    entry_points = {
+        "console_scripts" : [
+            "statsd-server = pystatsd.server:statsd_server_command"
+            ]}
 )


### PR DESCRIPTION
The server.py script is inside a package and not really callable directly after an installation using setup.py. 
This makes is quite inconvenient for launching from the command line. I've added a setuptools entry point that creates a script called statsd-server which calls a function that launches the server directly. 
