### PR TITLE
Added prefix argument to Client 

### DIFF
--- a/pystatsd/statsd.py
+++ b/pystatsd/statsd.py
@@ -10,7 +10,7 @@ import random
 # Sends statistics to the stats daemon over UDP
 class Client(object):
 
-    def __init__(self, host='localhost', port=8125):
+    def __init__(self, host='localhost', port=8125, prefix=None):
         """
         Create a new Statsd client.
         * host: the host where statsd is listening, defaults to localhost
@@ -21,6 +21,7 @@ class Client(object):
         """
         self.host = host
         self.port = int(port)
+        self.prefix = prefix
         self.log = logging.getLogger("pystatsd.client")
         self.udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
@@ -64,7 +65,8 @@ class Client(object):
         """
         addr = (self.host, self.port)
 
-        sampled_data = {}
+        if self.prefix:
+            data = dict((".".join((self.prefix, stat)), value) for stat, value in data.iteritems())
 
         if sample_rate < 1:
             if random.random() > sample_rate:


### PR DESCRIPTION
I've added an argument called prefix to the client which gets prepended to the front of each stat. I found this made life a lot easier for configuring clients for different environments and modules.

``` python
client = Client(prefix="example.dev")
client.increment("foo")
# increments example.dev.foo
```
