### PR TITLE
Graphite socket exception handling

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -1,5 +1,5 @@
 import re
-from socket import AF_INET, SOCK_DGRAM, error, socket
+import socket
 import threading
 import time
 import types
@@ -173,12 +173,12 @@ class Server(object):
         if self.transport == 'graphite':
             
             stat_string += "statsd.numStats %s %d\n" % (stats, ts)
-            graphite = socket()
+            graphite = socket.socket()
             try:
                 graphite.connect((self.graphite_host, self.graphite_port))
                 graphite.sendall(stat_string)
                 graphite.close()
-            except error, e:
+            except socket.error, e:
                 log.error("Error communicating with Graphite: %s" % e)
                 if self.debug:
                     print "Error communicating with Graphite: %s" % e
@@ -196,7 +196,7 @@ class Server(object):
     def serve(self, hostname='', port=8125):
         assert type(port) is types.IntType, 'port is not an integer: %s' % (port)
         addr = (hostname, port)
-        self._sock = socket(AF_INET, SOCK_DGRAM)
+        self._sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         self._sock.bind(addr)
 
         import signal


### PR DESCRIPTION
Without exception handling, pystatsd can hang forever.

If it can't connect to carbon the following traceback is seen and then nothing happens:

``` python
Exception in thread Thread-17:
Traceback (most recent call last):
  File "/usr/lib/python2.6/threading.py", line 532, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.6/threading.py", line 736, in run 
    self.function(*self.args, **self.kwargs)
  File "/usr/lib/pymodules/python2.6/pystatsd/server.py", line 177, in flush
    graphite.connect((self.graphite_host, self.graphite_port))
  File "<string>", line 1, in connect
error: [Errno 111] Connection refused
```
