### PR TITLE
Some changes (mostly to Debian packaging)

### DIFF
--- a/README
+++ b/README
@@ -36,10 +36,10 @@ Upstart init Script
 -------------
 Upstart is the daemon management system for Ubuntu, and it's really great!
 
-A basic upstart script has been included for the pystatd server. It's located 
+A basic upstart script has been included for the pystatsd server. It's located 
 under init/, and will be installed to /usr/share/doc if you build/install a 
-.deb file. The upstart script should be copied to /etc/init/pystatd.conf and 
-will read configuration variables from /etc/default/pystatd. By default the 
-pystatd daemon runs as user 'nobody' which is a good thing from a security 
+.deb file. The upstart script should be copied to /etc/init/pystatsd.conf and 
+will read configuration variables from /etc/default/pystatsd. By default the 
+pystatsd daemon runs as user 'nobody' which is a good thing from a security 
 perspective. 
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+python-statsd (1.0-3) UNRELEASED; urgency=low
+
+  [ Aaron Brady ]
+  * Be consistent about pystatsd vs. pystatd
+  * Fix upstart script with correct binary name
+  * Upgrade path for people with the previous package
+
+ -- Aaron Brady <bradya@gmail.com>  Thu, 01 Dec 2011 16:26:25 +0000
+
 python-statsd (1.0-2) UNRELEASED; urgency=low
 
   [ Rob Terhaar ]

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ -f "/etc/default/pystatd" ]; then
+	mv /etc/default/pystatd /etc/default/pystatsd
+fi
+
+if [ -f "/etc/init/pystatd.conf" ]; then
+	stop pystatd || true
+	cp /usr/share/doc/python-statsd/pystatsd.conf.upstart /etc/init/pystatsd.conf
+	start pystatsd || true
+fi
+
+#DEBHELPER#

--- a/debian/python-statsd.docs
+++ b/debian/python-statsd.docs
@@ -1,3 +1,3 @@
 README
-init/pystatd.conf.upstart
-init/pystatd.default
+init/pystatsd.conf.upstart
+init/pystatsd.default

--- a/init/pystatsd.conf.upstart
+++ b/init/pystatsd.conf.upstart
@@ -1,13 +1,13 @@
-# pystatd upstart script
+# pystatsd upstart script
 # 2011 - rob@atlanticdynamic.com
-# copy this to /etc/init/pystatd.conf 
+# copy this to /etc/init/pystatsd.conf 
 #
 
-description "start and stop the py-statd server"
+description "start and stop the pystatsd server"
 version "1.1"
 author "Rob Terhaar"
 
-description "py-statd server"
+description "pystatsd server"
 respawn limit 15 5
 #oom never
 
@@ -18,12 +18,12 @@ stop on shutdown
 respawn
 
 pre-start script
-  . /etc/default/pystatd
+  . /etc/default/pystatsd
 end script
 
 script
-  . /etc/default/pystatd
-  exec su -s /bin/sh -c "/usr/bin/pystatd-server \
+  . /etc/default/pystatsd
+  exec su -s /bin/sh -c "/usr/bin/pystatsd-server \
 --port $LOCAL_PYSTATD_PORT \
 --pct $PCT \
 --graphite-host $GRAPHITE_HOST \

--- a/init/pystatsd.default
+++ b/init/pystatsd.default
@@ -1,5 +1,5 @@
-# config file template for pystatd.
-# copy this to /etc/default/pystatad and the included upstart or init.d script,
+# config file template for pystatsd.
+# copy this to /etc/default/pystatsd and the included upstart or init.d script,
 # will read daemon settings from this file
 #
 LOCAL_PYSTATD_PORT=8125


### PR DESCRIPTION
This commit:
- Updates upstart configs with consistent names.
- Fixes the provided upstart script with correct binary name.
- Provides an upgrade path for people with the previous package. (If they already had an upstart job, copy the new one over it).

I'd been keen on this installing itself as a daemon, is there a reason that it doesn't launch by default? I'll happily modify the packaging to do that if it would be accepted.

Aaron
