### PR TITLE
py-statsd will only build on python2.6, dpkg-buildpackage won't work if 2.5 is installed. Fixed control File.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Section: python
 Priority: optional
 Standards-Version: 3.8.3
 Build-Depends: debhelper (>= 7.3), python-support (>= 1.0.3), python
-XS-Python-Version: all
+XS-Python-Version: >= 2.6
 Vcs-Git: https://github.com/robbyt/py-statsd
 Vcs-Browser: https://github.com/robbyt/py-statsd
 Homepage: https://github.com/robbyt/py-statsd


### PR DESCRIPTION
If you try to build python-statsd.dpkg on debian with python2.5 installed it will fail.

```
~/builds/python/py-statsd (master)$ dpkg-buildpackage -rfakeroot
dpkg-buildpackage: export CFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export CPPFLAGS from dpkg-buildflags (origin: vendor): 
dpkg-buildpackage: export CXXFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export FFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export LDFLAGS from dpkg-buildflags (origin: vendor): 
dpkg-buildpackage: source package python-statsd
dpkg-buildpackage: source version 1.0-2
dpkg-buildpackage: source changed by Rob Terhaar <rterhaar@atlanticdynamic.com>
dpkg-buildpackage: host architecture amd64
 dpkg-source --before-build py-statsd
 fakeroot debian/rules clean
dh --buildsystem=python_distutils clean
   dh_testdir -O--buildsystem=python_distutils
   dh_auto_clean -O--buildsystem=python_distutils
/home/buildmaster/builds/python/py-statsd/pystatsd/daemon.py:62: Warning: 'with' will become a reserved keyword in Python 2.6
Traceback (most recent call last):
  File "setup.py", line 3, in <module>
    from pystatsd import VERSION
  File "/home/buildmaster/builds/python/py-statsd/pystatsd/__init__.py", line 2, in <module>
    from server import Server
  File "/home/buildmaster/builds/python/py-statsd/pystatsd/server.py", line 17, in <module>
    from daemon import Daemon
  File "/home/buildmaster/builds/python/py-statsd/pystatsd/daemon.py", line 62
    with open(self.pidfile, 'w+') as fp:
            ^
SyntaxError: invalid syntax
dh_auto_clean: python2.5 setup.py clean -a returned exit code 1
make: *** [clean] Error 1
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
```

Setting python-version in control-file fixes it.
