### PR TITLE
Improve exception handling

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -112,6 +112,16 @@ class Server(object):
                     self.counters[key] = 0
                 self.counters[key] += float(fields[0] or 1) * (1 / sample_rate)
 
+    def on_timer(self):
+        """Executes flush(). Ignores any errors to make sure one exception
+        doesn't halt the whole flushing process.
+        """
+        try:
+            self.flush()
+        except Exception, e:
+            log.exception('Error while flushing: %s', e)
+        self._set_timer()
+
     def flush(self):
         ts = int(time.time())
         stats = 0
@@ -231,14 +241,12 @@ class Server(object):
                 if self.debug:
                     print "Error communicating with Graphite: %s" % e
 
-        self._set_timer()
-
         if self.debug:
             print "\n================== Flush completed. Waiting until next flush. Sent out %d metrics =======" \
                 % (stats)
 
     def _set_timer(self):
-        self._timer = threading.Timer(self.flush_interval / 1000, self.flush)
+        self._timer = threading.Timer(self.flush_interval / 1000, self.on_timer)
         self._timer.start()
 
     def serve(self, hostname='', port=8125):


### PR DESCRIPTION
Ignore exceptions while flushing and make sure a new timer is always set.

With the old code if there was any exception while flushing, e.g. an error while connecting to Graphite, the process would not flush anymore.
