### PR TITLE
fix timer handling, handle multimetric transmissions

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -202,7 +202,7 @@ class Server(object):
                     total = sum(v)
                     mean = total / count
 
-                self.timers[k] = []
+                del(self.timers[k])
 
                 if self.debug:
                     print "Sending %s ====> lower=%s, mean=%s, upper=%s, %dpct=%s, count=%s" \


### PR DESCRIPTION
This branch has three related changes:
1. do not treat any unknown type data as a counter; drop it and warn
2. when a timer is flushed, delete it rather than resetting it; resetting was leading to fatal errors
3. accept transmissions containing multiple metrics at once, and cope with trailing newlines

Each issue is explained slightly more in detail on the relevant commit.

Without these changes:
- all metrics sent from some clients, like Perl's Etsy::Statsd, are treated like counters
- timers basically don't work at all
- any client that can send more than one metric at once has much of its data dropped on the floor
