### PR TITLE
when logging sent gauge, call values "values" not "counts"

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -160,7 +160,7 @@ class Server(object):
             v = float(v)
 
             if self.debug:
-                print "Sending %s => count=%s" % (k, v)
+                print "Sending %s => value=%s" % (k, v)
 
             if self.transport == 'graphite':
                 # note: counters and gauges implicitly end up in the same namespace


### PR DESCRIPTION
Gauges have values, not counts, and we should log it that way.  It helps us see what kind of metrics we were collecting, too.
