### PR TITLE
fully clear gauges and counters after sending

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -147,8 +147,8 @@ class Server(object):
             elif self.transport == 'ganglia-gmetric':
                 self.send_to_ganglia_using_gmetric(k,v, "_counters", "count")
 
-            # Zero out the counters once the data is sent
-            self.counters[k] = [0, int(time.time())]
+            # Clear the counter once the data is sent
+            del(self.counters[k])
             stats += 1
 
         for k, (v, t) in self.gauges.items():
@@ -171,6 +171,7 @@ class Server(object):
             elif self.transport == 'ganglia-gmetric':
                 self.send_to_ganglia_using_gmetric(k,v, "_gauges", "gauge")
 
+            del(self.gauges[k])
             stats += 1
 
         for k, (v, t) in self.timers.items():


### PR DESCRIPTION
Without this commit, counters and gauges that have been seen before
will be sent over and over, each differently.

Counters will be reset to 0 after their sending, and will send that
zero over and over.  Gauges will not reset at all, and will send
their new value repeatedly.

To confirm that this is currently the case, I changed the debug
output to include the timestamp:

```
print "Sending %s => count=%s @ %s" % (k, v, ts)
```

After sending a counter and gauge only once each:

```
Sending foo-counter => count=0.1 @ 1371864200
Sending foo-gauge => count=123.0 @ 1371864200

[ …10s go by… ]

Sending foo-counter => count=0.0 @ 1371864210
Sending foo-gauge => count=123.0 @ 1371864210
```
