### PR TITLE
By default gauge values should not be deleted

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -200,7 +200,6 @@ class Server(object):
             elif self.transport == 'ganglia-gmetric':
                 self.send_to_ganglia_using_gmetric(k,v, "_gauges", "gauge")
 
-            del(self.gauges[k])
             stats += 1
 
         for k, (v, t) in self.timers.items():


### PR DESCRIPTION
The original statsd documentation states, that gauge values will be send every flush interval and if no update happens, the old value will be used, which did not work in pystatsd.
