### PR TITLE
Fix poison data

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -306,7 +306,7 @@ class Server(object):
             data, addr = self._sock.recvfrom(self.buf)
             try:
                 self.process(data)
-            except Exception as error:
+            except Exception, error:
                 log.error("Bad data from %s: %s",addr,error) 
 
 


### PR DESCRIPTION
I discovered that sending bad data to the server would crash the main thread, leaving the flush thread to run, which is kind of useless, as no new data could be submitted.
