### PR TITLE
Add an option to include an API key for http://hostedgraphite.com

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -369,7 +369,7 @@ def run_server():
     # 
     parser.add_argument('--flush-interval', dest='flush_interval', help='how often to send data to graphite in millis (default: 10000)', type=int, default=10000)
     parser.add_argument('--no-aggregate-counters', dest='no_aggregate_counters', help='should statsd report counters as absolute instead of count/sec', action='store_true')
-    parser.add_argument('--global-prefix', dest='global_prefix', help='prefix to append to all stats sent to graphite. Useful for hosted services (ex: Hosted Graphite) (default: None)', type=str, default=None)
+    parser.add_argument('--global-prefix', dest='global_prefix', help='prefix to append to all stats sent to graphite. Useful for hosted services (ex: Hosted Graphite) or stats namespacing (default: None)', type=str, default=None)
     parser.add_argument('--counters-prefix', dest='counters_prefix', help='prefix to append before sending counter data to graphite (default: stats)', type=str, default='stats')
     parser.add_argument('--timers-prefix', dest='timers_prefix', help='prefix to append before sending timing data to graphite (default: stats.timers)', type=str, default='stats.timers')
     parser.add_argument('-t', '--pct', dest='pct', help='stats pct threshold (default: 90)', type=int, default=90)


### PR DESCRIPTION
This adds support for using Hosted Graphite (http://hostedgraphite.com).

Basics are:
- Added a command-line option
- Added option to Server **init**
- Prepend all stats like `APIKEY.<stat>`

Thoughts?

EDIT: Updated code to be more generic, use `global-prefix` option. Better for supporting multiple services and/or global-namespacing of stats.
