### PR TITLE
server.py now allows empty string prefix

### DIFF
--- a/pystatsd/server.py
+++ b/pystatsd/server.py
@@ -80,7 +80,7 @@ class Server(object):
         self.expire = expire
 
         # For services like Hosted Graphite, etc.
-        self.global_prefix = global_prefix + '.' if timers_prefix else ''
+        self.global_prefix = global_prefix + '.' if global_prefix else ''
 
         self.counters = {}
         self.timers = {}


### PR DESCRIPTION
In the previous implementation, when passing the empty string to the prefix parameter, the final key constructed was .key when it should have been key.
