### PR TITLE
Timing is expected in ms, but timing_since sends μs.

### DIFF
--- a/pystatsd/statsd.py
+++ b/pystatsd/statsd.py
@@ -31,16 +31,16 @@ class Client(object):
 
     def timing_since(self, stat, start, sample_rate=1):
         """
-        Log timing information as the number of microseconds since the provided time float
+        Log timing information as the number of milliseconds since the provided time float
         >>> start = time.time()
         >>> # do stuff
         >>> statsd_client.timing_since('some.time', start)
         """
-        self.timing(stat, int((time.time() - start) * 1000000), sample_rate)
+        self.timing(stat, (time.time() - start) * 1000, sample_rate)
 
     def timing(self, stat, time, sample_rate=1):
         """
-        Log timing information for a single stat
+        Log timing information for a single stat, in milliseconds
         >>> statsd_client.timing('some.time',500)
         """
         stats = {stat: "%f|ms" % time}

--- a/tests/client.py
+++ b/tests/client.py
@@ -95,16 +95,15 @@ class ClientBasicsTestCase(unittest.TestCase):
             bytes(stat_str, 'utf-8'), self.addr)
 
     def test_basic_client_timing_since(self):
-        ts = (1971, 6, 29, 4, 13, 0, 0, 0, -1)
-        now = time.mktime(ts)
-        # add 5 seconds
-        ts = (1971, 6, 29, 4, 13, 5, 0, 0, -1)
-        then = time.mktime(ts)
+        # arbitrary start timestamp value
+        now = 1000.00
+        # five and a half seconds later
+        then = now + 5.5
         mock_time_patcher = mock.patch('time.time', return_value=now)
         mock_time_patcher.start()
 
         stat = 'pystatsd.unittests.test_basic_client_timing_since.time'
-        stat_str = stat + ':-5000000.000000|ms'
+        stat_str = stat + ':-5500.000000|ms'
 
         self.client.timing_since(stat, then)
 


### PR DESCRIPTION
Fixing a bug reported in number of issues so far:
Fixes #31
Fixes #44
Fixes #93

Unit test was also measuring μs while it says it's measuring ms. Maybe the interface of the `timing_since` method shouldn't be seconds at all - for consistency it should be milliseconds for all timing methods. I can change it, what do you think?
