### PR TITLE
Travis CI: Remove EOL versions of Python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,11 @@ language: python
 
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
 
-matrix:
-  include:
-    - python: 3.7
-      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
-      
 install:
   - "pip install -r requirements.txt"
   - "python setup.py -q install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,19 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.3"
 
-# command to install dependencies
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+      
 install:
-  - "pip install -r requirements.txt --use-mirrors"
+  - "pip install -r requirements.txt"
   - "python setup.py -q install"
 
-# command to run tests
 script: nosetests tests


### PR DESCRIPTION
Python 2.6 and 3.3 are End of Life.  Test on currently supported versions of CPython instead.