### PR TITLE
Update version number

### DIFF
--- a/pystatsd/__init__.py
+++ b/pystatsd/__init__.py
@@ -1,4 +1,4 @@
 from .statsd import Client
 from .server import Server
 
-VERSION = (0, 1, 10)
+VERSION = (0, 1, 11)


### PR DESCRIPTION
`0.1.11` was tagged as 69e362654c37df28582b12b964901334326620a7 but pystatsd.VERSION was not updated. Presumably this is part of why PyPI still shows `0.1.10` as the [most-recent release](https://pypi.org/project/pystatsd/).