### PR TITLE
Add content-type for long_description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     license = "BSD",
     packages=['pystatsd'],
     long_description=read('README.md'),
+    long_description_content_type='text/markdown',
     classifiers=[
         "License :: OSI Approved :: BSD License",
     ],


### PR DESCRIPTION
PyPI defaults to text/x-rst, but we're using markdown. This should improve project description rendering on PyPI.

This also allows `twine check` to pass on sdists, wheels, etc.