### PR TITLE
setup.py: Add PyPI trove classifiers for Py2.7, 3.5-3.8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ setup(
     long_description=read('README.md'),
     classifiers=[
         "License :: OSI Approved :: BSD License",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
     scripts=['bin/pystatsd-server']
 )


### PR DESCRIPTION
Adds compatibility information to https://pypi.org/project/pystatsd on the next release.